### PR TITLE
Improve dice in multiple ways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Next]
 
 **Changed**:
+- Decrease required Ruby version to 3.0.0 (from 3.1.0).
 - Rewrite `BruteForce` calculator to be an order of magnitude faster. Uses `Enumerator::Product` if available, otherwise a better implementation than before.
+- Change how rolling works to make rolls with very large dice significantly faster. Also optimize numeric dice initialization.
 
 **Fixed**:
 - Allow calling calculators with an empty list, returning an empty hash.

--- a/bin/benchmark
+++ b/bin/benchmark
@@ -27,6 +27,7 @@ report_path = "tmp/benchmark #{Time.now.iso8601} " \
 StackProf.run(mode: :cpu, raw: true, out: "tmp/stackprof.dump") do
   Benchmark.ips do |ips|
     ips.report("Brute") { Dicey::SumFrequencyCalculators::BruteForce.new.call(Dicey::RegularDie.create_dice(6, 6)) }
+    ips.report("Rolling") { Dicey::RegularDie.new(10_000).roll }
 
     ips.json!(report_path)
   end

--- a/lib/dicey/numeric_die.rb
+++ b/lib/dicey/numeric_die.rb
@@ -8,9 +8,16 @@ module Dicey
     # @param sides_list [Enumerable<Numeric>]
     # @raise [DiceyError] if +sides_list+ contains non-numerical values or is empty
     def initialize(sides_list)
-      sides_list.each do |value|
-        raise DiceyError, "`#{value}` is not a number!" unless value.is_a?(Numeric)
+      if Range === sides_list
+        unless Numeric === sides_list.begin && Numeric === sides_list.end
+          raise DiceyError, "`#{sides_list.inspect}` is not a numerical range!"
+        end
+      else
+        sides_list.each do |value|
+          raise DiceyError, "`#{value.inspect}` is not a number!" unless Numeric === value
+        end
       end
+
       super
     end
   end

--- a/lib/dicey/regular_die.rb
+++ b/lib/dicey/regular_die.rb
@@ -11,15 +11,19 @@ module Dicey
     # Create a list of regular dice with the same number of sides.
     #
     # @param dice [Integer]
-    # @param sides [Integer]
+    # @param max [Integer]
     # @return [Array<RegularDie>]
-    def self.create_dice(dice, sides)
-      (1..dice).map { new(sides) }
+    def self.create_dice(dice, max)
+      (1..dice).map { new(max) }
     end
 
-    # @param sides [Integer]
-    def initialize(sides)
-      super((1..sides))
+    # @param max [Integer]
+    def initialize(max)
+      unless Integer === max && max.positive?
+        raise DiceyError, "regular dice can contain only positive integers, #{max.inspect} is not"
+      end
+
+      super((1..max))
     end
 
     # Dice with 1–6 sides are displayed with a single character.

--- a/spec/dicey/abstract_die_spec.rb
+++ b/spec/dicey/abstract_die_spec.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+module Dicey
+  RSpec.describe AbstractDie do
+    subject(:die) { described_class.new(sides) }
+    let(:sides) { Array.new(rand(3..12)) { rand } }
+
+    let(:custom_die_class) do
+      Class.new(described_class) { def to_s = sides_list.join("-") }
+    end
+
+    describe ".rand" do
+      it "returns a random number" do
+        expect(described_class.rand).to be_between(0, 1)
+        expect(described_class.rand(3)).to be_between(0, 2)
+        expect(described_class.rand(5...10)).to be_between(5, 9)
+      end
+    end
+
+    describe ".srand" do
+      it "sets the random seed for reproducible results" do
+        described_class.srand(493_525)
+        numbers = Array.new(10) { described_class.rand }
+
+        described_class.srand(493_525)
+        new_numbers = Array.new(10) { described_class.rand }
+        expect(new_numbers).to eq numbers
+      end
+    end
+
+    context "when a descendant class uses .rand/.srand" do
+      it "uses the same randomizer instance" do
+        described_class.srand(255_394)
+        numbers = Array.new(10) { described_class.rand }
+
+        custom_die_class.srand(255_394)
+        new_numbers = Array.new(5) { custom_die_class.rand } + Array.new(5) { described_class.rand }
+        expect(new_numbers).to eq numbers
+      end
+    end
+
+    describe ".describe" do
+      subject(:description) { described_class.describe(dice) }
+
+      context "when called with one die" do
+        let(:dice) { described_class.new([5, 5, 0.5]) }
+
+        it "returns a string description of the die" do
+          expect(description).to eq "(5,5,0.5)"
+        end
+      end
+
+      context "when called with one die in a list" do
+        let(:dice) { [described_class.new([-1, -0.9, 0.1])] }
+
+        it "returns a string description of the die" do
+          expect(description).to eq "(-1,-0.9,0.1)"
+        end
+      end
+
+      context "when called with multiple dice" do
+        let(:dice) { [described_class.new([5, 5, 0.5]), described_class.new([1, 2, 3])] }
+
+        it "returns a string description of the dice in the order provided" do
+          expect(description).to eq "(5,5,0.5);(1,2,3)"
+        end
+      end
+
+      context "when called with different die classes" do
+        let(:dice) { [custom_die_class.new([5, 5, 0.5]), described_class.new([1, 2, 3])] }
+
+        it "returns a concatenated list of their #to_s" do
+          expect(description).to eq "5-5-0.5;(1,2,3)"
+        end
+      end
+
+      context "when called on a different die class" do
+        subject(:description) { custom_die_class.describe(dice) }
+
+        let(:dice) { [described_class.new([5, 5, 0.5]), custom_die_class.new([1, 2, 3])] }
+
+        it "returns a string description of the dice in the order provided" do
+          expect(description).to eq "(5,5,0.5);1-2-3"
+        end
+      end
+
+      context "when called with a non-Array list" do
+        let(:dice) { [described_class.new([5, 5, 0.5])].each + [described_class.new([1, 2, 3])] }
+
+        it "works the same as with an Array" do
+          expect(description).to eq "(5,5,0.5);(1,2,3)"
+        end
+      end
+    end
+
+    describe ".new" do
+      it "makes a frozen copy of the list of sides" do
+        expect(die.sides_list).to be_frozen
+
+        expect(die.sides_list).to eq sides
+        sides << 13.13
+        expect(die.sides_list).to eq sides[0...-1]
+      end
+
+      it "allows any kinds of sides" do
+        cool_die = described_class.new([1, 2, 3, "a", "b", "c"])
+        expect(cool_die.sides_list).to eq [1, 2, 3, "a", "b", "c"]
+      end
+
+      context "if given a Range" do
+        let(:sides) { ("a".."c") }
+
+        it "transforms it into an Array" do
+          expect(die.sides_list).to eq %w[a b c]
+          expect(die.sides_list).to be_frozen
+        end
+      end
+
+      context "if the list of sides is empty" do
+        it "raises DiceyError" do
+          expect { described_class.new([]) }.to raise_error(DiceyError)
+        end
+      end
+    end
+
+    describe "#sides_list" do
+      it "returns the list of sides" do
+        expect(die.sides_list).to eq sides
+      end
+    end
+
+    describe "#sides_num" do
+      it "returns the number of sides" do
+        expect(die.sides_num).to eq sides.size
+      end
+    end
+
+    describe "#current" do
+      it "returns the current value, without advancing the die" do
+        expect(die.current).to be sides.first
+        # For good measure
+        expect(die.current).to be sides.first
+      end
+    end
+
+    describe "#next" do
+      it "returns the current value, advancing the die" do
+        expect(die.next).to be sides[0]
+        expect(die.current).to be sides[1]
+        expect(die.next).to be sides[1]
+        expect(die.current).to be sides[2]
+      end
+
+      it "wraps around the die" do
+        (die.sides_num + 2).times { die.next }
+        expect(die.current).to be sides[2]
+      end
+    end
+
+    describe "#roll" do
+      subject(:rolled_side) { die.roll }
+
+      it "returns a random side, advancing the die to it" do
+        expect(sides).to include rolled_side
+        expect(die.current).to be rolled_side
+      end
+
+      it "uses class's .rand for reproducible results" do
+        seed = rand
+
+        die.class.srand(seed)
+        roll = die.class.new(sides).roll
+
+        die.class.srand(seed)
+        expect(rolled_side).to be roll
+      end
+    end
+
+    describe "#to_s" do
+      it "returns a bracketed list of die's sides" do
+        expect(die.to_s).to eq "(#{sides.join(",")})"
+      end
+    end
+
+    describe "#==" do
+      it "returns true if the other die has the same list of sides, irrespective of class" do
+        expect(die == custom_die_class.new(sides)).to be true
+      end
+
+      it "returns false if the other die has a different list of sides" do
+        expect(die == described_class.new(sides + [1])).to be false
+      end
+    end
+
+    describe "#eql?" do
+      it "returns true if the other die has the same list of sides and the same class" do
+        expect(die.eql?(described_class.new(sides))).to be true
+      end
+
+      it "returns false if the other die has the same list of sides but different class" do
+        expect(die.eql?(custom_die_class.new(sides))).to be true
+      end
+
+      it "returns false if the other die has a different list of sides" do
+        expect(die.eql?(described_class.new(sides + [1]))).to be false
+      end
+    end
+
+    describe "#hash" do
+      it "returns the same hash as for a die with the same list of sides and the same class" do
+        expect(die.hash).to eq described_class.new(sides).hash
+      end
+
+      it "returns different hash than for a die with the same list of sides but different class" do
+        expect(die.hash).not_to eq custom_die_class.new(sides).hash
+      end
+
+      it "returns different hash than for a die with a different list of sides" do
+        expect(die.hash).not_to eq described_class.new(sides + [1]).hash
+      end
+    end
+  end
+end

--- a/spec/dicey/numeric_die_spec.rb
+++ b/spec/dicey/numeric_die_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Dicey
+  RSpec.describe NumericDie do
+    describe ".new" do
+      subject(:die) { described_class.new(sides) }
+      let(:sides) { Array.new(rand(3..12)) { rand } }
+
+      it "makes a frozen copy of the list of sides" do
+        expect(die.sides_list).to be_frozen
+
+        expect(die.sides_list).to eq sides
+        sides << 13.13
+        expect(die.sides_list).to eq sides[0...-1]
+      end
+
+      context "if given a Range" do
+        let(:sides) { (1..5) }
+
+        it "transforms it into an Array" do
+          expect(die.sides_list).to eq [1, 2, 3, 4, 5]
+          expect(die.sides_list).to be_frozen
+        end
+      end
+
+      context "if list of sides contains non-numerical values" do
+        it "raises DiceyError" do
+          expect { described_class.new([1, 2, 3, "a", "b", "c"]) }.to raise_error(DiceyError)
+          expect { described_class.new("a".."c") }.to raise_error(DiceyError)
+        end
+      end
+
+      context "if list of sides is empty" do
+        it "raises DiceyError" do
+          expect { described_class.new([]) }.to raise_error(DiceyError)
+        end
+      end
+    end
+  end
+end

--- a/spec/dicey/regular_die_spec.rb
+++ b/spec/dicey/regular_die_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Dicey
+  RSpec.describe RegularDie do
+    describe ".create_dice" do
+      subject(:dice) { described_class.create_dice(dice_num, max) }
+      let(:dice_num) { rand(3..12) }
+      let(:max) { rand(3..12) }
+
+      it "makes a list of dice with the same number of sides" do
+        expect(dice).to all be_a(described_class)
+        expect(dice).to all have_attributes(sides_num: max)
+      end
+    end
+
+    describe ".new" do
+      subject(:die) { described_class.new(max) }
+      let(:max) { rand(3..12) }
+
+      it "makes a die with sides from 1 to max" do
+        expect(die.sides_list).to be_frozen
+        expect(die.sides_list).to eq (1..max).to_a
+      end
+
+      it "can make a 1-sided die" do
+        expect(described_class.new(1).sides_list).to eq [1]
+      end
+
+      context "if given a non-Integer" do
+        it "raises DiceyError" do
+          expect { described_class.new([]) }.to raise_error(DiceyError)
+          expect { described_class.new("c") }.to raise_error(DiceyError)
+          expect { described_class.new(nil) }.to raise_error(DiceyError)
+          expect { described_class.new(1.5) }.to raise_error(DiceyError)
+        end
+      end
+
+      context "if given a non-positive Integer" do
+        it "raises DiceyError" do
+          expect { described_class.new(0) }.to raise_error(DiceyError)
+          expect { described_class.new(-1) }.to raise_error(DiceyError)
+        end
+      end
+    end
+
+    describe "#to_s" do
+      subject(:text) { die.to_s }
+
+      context "when die has 1–6 sides" do
+        let(:die) { described_class.new(rand(1..6)) }
+
+        it "returns a Unicode character for die" do
+          expect(text.size).to eq 1
+          expect(text).to be_between("⚀", "⚅")
+        end
+      end
+
+      context "when die has more than 6 sides" do
+        let(:die) { described_class.new(rand(7..12)) }
+
+        it "returns die's maximum value in square brackets" do
+          expect(text).to eq "[#{die.sides_num}]"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Simplify state management in `AbstractDie`, making rolling faster.
* Special-case Range argument in `NumericDie#initialize`.
* Add `#eql?` and `#hash`.
* Write comprehensive tests for dice.
* Improve argument checking.
* Allow single die in `AbstraceDie.describe`.