### PR TITLE
Don't run Zizmor when nothing in ".github" was changed

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -3,8 +3,10 @@ name: GitHub Actions Security Analysis with zizmor 🌈
 on:
   push:
     branches: ["main"]
+    paths: [".github/**/*"]
   pull_request:
     branches: ["**"]
+    paths: [".github/**/*"]
 
 permissions: {}
 
@@ -18,6 +20,5 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
-
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2


### PR DESCRIPTION
It may seem that the correct path spec would be ".github/workflows/*", but there may be other configuration changes (to Zizmor's config, for example) that need the check to run again.